### PR TITLE
Bumped geerlingguy.php to 3.6.3 to make it work with Ansible 2.7.0

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: geerlingguy.php
-  version: "3.2.2"
+  version: "3.6.3"
 - src: geerlingguy.composer
   version: "1.4.1"
 - src: jdauphant.nginx

--- a/ansible/roles/php/requirements.yml
+++ b/ansible/roles/php/requirements.yml
@@ -1,5 +1,5 @@
 ---
 - src: geerlingguy.php
-  version: 3.2.2
+  version: 3.6.3
 - src: geerlingguy.composer
   version: 1.4.1


### PR DESCRIPTION
geerlingguy.php cannot be installed with Ansible 2.7.0 on CentOS7 because Ansible 2.7.0 cannot handle the empty repository string. This has been fixed in geerlingguy.php 3.6.3.